### PR TITLE
Update devcontainer settings for .NET 8

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,8 +23,8 @@
   "features": {
     // Uncomment the below to install .NET SDK
     "ghcr.io/devcontainers/features/dotnet:latest": {
-      "version": "latest",
-      "additionalVersions": "lts"
+      "version": "6.0",
+      "additionalVersions": "7.0"
     },
 
     // Uncomment the below to install Azure CLI
@@ -132,12 +132,13 @@
       }
     }
   },
-	"containerEnv": {
-      "AZURE_OPENAI_CHAT_DEPLOYMENT": "",
-      "AZURE_OPENAI_EMBEDDING_DEPLOYMENT": "",
-		  "AZURE_OPENAI_ENDPOINT": "",
-      "AZURE_OPENAI_KEY": "",
-		  "QDRANT_HOST": ""
+
+  "containerEnv": {
+    "AZURE_OPENAI_CHAT_DEPLOYMENT": "",
+    "AZURE_OPENAI_EMBEDDING_DEPLOYMENT": "",
+    "AZURE_OPENAI_ENDPOINT": "",
+    "AZURE_OPENAI_KEY": "",
+    "QDRANT_HOST": ""
   },
 
   // Uncomment if you want to use bash in 'onCreateCommand' after the container is created

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -23,6 +23,10 @@ dotnet dev-certs https --trust
 # Uncomment the below to install Azure Bicep CLI.
 az bicep install
 
+## GitHub Copilot CLI ##
+# Uncomment the below to install Azure Bicep CLI.
+gh extension install github/gh-copilot
+
 ## AZURE FUNCTIONS CORE TOOLS ##
 # Uncomment the below to install Azure Functions Core Tools. Make sure you have installed node.js
 npm i -g azure-functions-core-tools@4 --unsafe-perm true

--- a/2023/Web Track/Blazor/complete/global.json
+++ b/2023/Web Track/Blazor/complete/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2.23502.2"
+    "allowPrerelease": true
   }
 }

--- a/2023/Web Track/Blazor/start/global.json
+++ b/2023/Web Track/Blazor/start/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2.23502.2"
+    "allowPrerelease": true
   }
 }


### PR DESCRIPTION
This PR is:

- To update devcontainer settings to use .NET 6, 7, and 8
- To install GitHub Copilot extension in GitHub CLI

